### PR TITLE
Docs: use the scoped @webship/diffy-steps require path (#304)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ The Diffy step-pack was extracted to its own plugin,
 [`diffy-steps`](https://github.com/webship/diffy-steps). webship-js no
 longer ships `tests/step-definitions-diffy/`, the `diffy`
 `worldParameters` block, or the mock Diffy API. Consumers install the
-plugin and add `node_modules/diffy-steps/tests/step-definitions/**/*.js`
+plugin and add `node_modules/@webship/diffy-steps/tests/step-definitions/**/*.js`
 to their own `require:` list. Nothing in this repo depends on it — the
 steps only ever used `@cucumber/cucumber`, `axios`, and Node built-ins.
 Treat any `diffy` question as a `diffy-steps` question.


### PR DESCRIPTION
One-line correction to the `CLAUDE.md` §2.6 pointer added in #303.

```diff
-plugin and add `node_modules/diffy-steps/tests/step-definitions/**/*.js`
+plugin and add `node_modules/@webship/diffy-steps/tests/step-definitions/**/*.js`
```

Closes #304

The extracted plugin publishes under the `@webship` scope
([webship/diffy-steps#1](https://github.com/webship/diffy-steps/issues/1)), so
npm installs it into `node_modules/@webship/diffy-steps/`. The unscoped path
matches nothing — a reader following the instruction gets every Diffy step
reported as undefined, with no hint as to why.

The scoping landed after #303 was merged, so the pointer was accurate when it
was written.

## Scope

Only the `require:` path changes. The plain-text `diffy-steps` mentions in
`CLAUDE.md` prose, the `AGENTS.md` source map, and the `docs/README.md` note all
refer to the GitHub repository, which is still `webship/diffy-steps` — those are
correct and untouched.

## Test notes

Documentation only, one line. Verified there are no other `node_modules/diffy-steps`
occurrences in the tree.

AI-Generated: Yes (spotted and corrected the stale path; reviewed by Rajab Natshah.)

### Checkpoints

- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] ~Automated unit/functional testing coverage~
- [x] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] Accessibility and Readability
- [x] Reviewed by a human
- [x] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
