### PR TITLE
Docs: use the @webship-js scope for the diffy-steps path (#306)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@ The Diffy step-pack was extracted to its own plugin,
 [`diffy-steps`](https://github.com/webship/diffy-steps). webship-js no
 longer ships `tests/step-definitions-diffy/`, the `diffy`
 `worldParameters` block, or the mock Diffy API. Consumers install the
-plugin and add `node_modules/@webship/diffy-steps/tests/step-definitions/**/*.js`
+plugin and add `node_modules/@webship-js/diffy-steps/tests/step-definitions/**/*.js`
 to their own `require:` list. Nothing in this repo depends on it — the
 steps only ever used `@cucumber/cucumber`, `axios`, and Node built-ins.
 Treat any `diffy` question as a `diffy-steps` question.


### PR DESCRIPTION
One-line correction to the `CLAUDE.md` §2.6 pointer.

```diff
-plugin and add `node_modules/@webship/diffy-steps/tests/step-definitions/**/*.js`
+plugin and add `node_modules/@webship-js/diffy-steps/tests/step-definitions/**/*.js`
```

Closes #306

The plugin was rescoped to `@webship-js/diffy-steps`
([webship/diffy-steps#3](https://github.com/webship/diffy-steps/issues/3)) —
`@webship` is the GitHub organisation for the whole Webship product family,
while this package plugs into the webship-js harness specifically.

The old path names a directory npm will never create, so a reader following
§2.6 adds a `require:` glob that matches nothing and gets every Diffy step
reported as undefined.

Same line as #304/#305, which fixed the *unscoped* path; the scope has since
changed again. The plugin is still unpublished, so the scope is settling at no
cost — but the pointer has to follow it.

## Scope

Only the `require:` path. The plain-text `diffy-steps` mentions in `CLAUDE.md`
prose, the `AGENTS.md` source map, and the `docs/README.md` note refer to the
GitHub repository, still `webship/diffy-steps` — correct and untouched.

## Test notes

Documentation only, one line. Verified no other `@webship/` occurrences remain
in the tree.

AI-Generated: Yes (tracked the rescope through to the pointer; reviewed by Rajab Natshah.)

### Checkpoints

- [x] File an issue about this project
- [x] Addition/Change/Update/Fix to this project
- [ ] Testing to ensure no regression
- [ ] ~Automated unit/functional testing coverage~
- [x] Developer Documentation support on feature change/addition
- [ ] User Guide Documentation support on feature change/addition
- [ ] Accessibility and Readability
- [ ] Reviewed by a human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Update Release Notes
- [ ] Release
